### PR TITLE
potential fix to #77

### DIFF
--- a/eos-update
+++ b/eos-update
@@ -71,7 +71,7 @@ IsEndeavourOS() {
 }
 
 DiskSpace() {
-    local available=$(LANG=C /usr/bin/df | /usr/bin/grep -w "/" | /usr/bin/awk '{print $4}' | head -n 1)
+    local available=$(LANG=C /usr/bin/df | /usr/bin/grep -E '[[:blank:]]/$' | /usr/bin/awk '{print $4}')
     local min=$((min_free_bytes / 1000))  # use compatible numbers
 
     if [ $available -lt $min ] ; then

--- a/eos-update
+++ b/eos-update
@@ -71,7 +71,7 @@ IsEndeavourOS() {
 }
 
 DiskSpace() {
-    local available=$(LANG=C /usr/bin/df | /usr/bin/grep -w "/" | /usr/bin/awk '{print $4}')
+    local available=$(LANG=C /usr/bin/df | /usr/bin/grep -w "/" | /usr/bin/awk '{print $4}' | head -n 1)
     local min=$((min_free_bytes / 1000))  # use compatible numbers
 
     if [ $available -lt $min ] ; then


### PR DESCRIPTION
this will ensure the output of 

```
/usr/bin/df | /usr/bin/grep -E '[[:blank:]]/$' | /usr/bin/awk '{print $4}
```

is cut to the first line. thus making sure only / is used and not other mounts. 

in my case `/usr/bin/df | /usr/bin/grep -w "/"` produces:

```
/dev/nvme0n1p2           888291700  320254216  522841080   38% /
//192.168.2.40/4tb      2884077824 1924402372  959675452   67% /mnt/4tb
//192.168.2.40/bigstore 3771181952 2320213632 1450968320   62% /mnt/bigstore
```

whereas `/usr/bin/df | /usr/bin/grep -E '[[:blank:]]/$' ` produces:

```
/dev/nvme0n1p2           888291700  320243476  522851820   38% /
```

which I think is the desired output. 