### PR TITLE
Fix eos-update-extras receiving one quoted parameter instead of multiple

### DIFF
--- a/eos-update
+++ b/eos-update
@@ -374,7 +374,7 @@ eos_update_sudofunc() {
     rm -$rmopt $lock
     if [ ! -e $lock ] ; then
         pacman -Sy                         || return
-        ${progname}-extras "${subopts[@]}" || return
+        ${progname}-extras ${subopts[@]}   || return
         pacman -Su                         || return
         $pacdiffer
         $sync
@@ -393,7 +393,7 @@ eos_update_sudofunc() {
     rm -$rmopt $lock
     if [ ! -e $lock ] ; then
         pacman -Sy                        || return
-        ${progname}-extras "${subopts[@]}" || return
+        ${progname}-extras ${subopts[@]}  || return
         pacman -Su                        || return
         $helper2                          || return             # Note: 'paru' returns 1 on error, but 'yay' does not!
         $pacdiffer


### PR DESCRIPTION
Because it is written in a $cmdfile, quoting the $subopts resulted in `eos-update-extras "--nvidia --keyrings"` and case switch couldn't parse correctly. In this heredoc, there is no need for $subopts to be quoted, similar to how $progname is not quoted either.