### PR TITLE
Add 0x45 to eos-sendlog

### DIFF
--- a/eos-sendlog
+++ b/eos-sendlog
@@ -8,7 +8,7 @@ Verbose() { [ $verbose = yes ] && echo -e "$@" >&2 ; }
 Options() {
     local opts
     local sopts="e:hv"
-    local lopts="0x0,dpaste,termbin"       # pastebin options
+    local lopts="0x0,0x45,dpaste,termbin"       # pastebin options
     lopts+=",expire:,help,verbose,no-yad"  # general options
 
     opts="$(/bin/getopt -o="$sopts" --longoptions "$lopts" --name "$progname" -- "$@")" || Usage 1
@@ -18,7 +18,7 @@ Options() {
         case "$1" in
             -h | --help)                   Usage 0 ;;
             -v | --verbose)                verbose=yes ;;
-            --0x0 | --dpaste | --termbin)  helper_options+=("$1") ;;
+            --0x0 | --0x45 | --dpaste | --termbin)  helper_options+=("$1") ;;
             -e | --expire)                 helper_options+=(--expire="$2"); shift ;;
             --no-yad)                      helper_options+=($1) ;;
             --)                            shift; break ;;
@@ -38,18 +38,20 @@ Usage:
           $progname [$progname-options] "<command1> ; <command2> ; <command3> ..."
 ${progname}-options:
     --0x0           Use only pastebin 0x0.st.
+    --0x45          Use only pastebin 0x45.st.
     --dpaste        Use only pastebin dpaste.com.
     --termbin       Use only pastebin termbin.com.
     --help, -h      This help.
     --verbose, -v   Be more verbose.
     --expire, -e    The URL will expire in X days. Default: $expire_def.
-                    Currently supported only for 0x0.st.
+                    Currently supported only for 0x0.st and 0x45.st.
     --no-yad        Prevent using yad messages (useful if display cannot be opened).
 
 Without ${progname}-options the services are tried in order:
     1. 0x0
-    2. dpaste
-    3. termbin
+    2. 0x45
+    3. dpaste
+    4. termbin
 until one succeeds or all fail.
 
 Examples:

--- a/eos-sendlog-helper
+++ b/eos-sendlog-helper
@@ -11,6 +11,7 @@ $progname sends the input (stdin) to a pastebin service.
 Usage: $progname [options] command-string
 Options:
    --0x0         Uses 0x0.st
+   --0x45        Uses 0x45.st
    --dpaste      Uses dpaste.com
    --termbin     Uses termbin.com
    --help, -h    This help
@@ -18,7 +19,7 @@ Options:
    --no-yad      Prevent using yad messages.
 
 Without options the services are tried in order until one succeeds or all fail.
-Trial order: 0x0 dpaste termbin.
+Trial order: 0x0 0x45 dpaste termbin.
 EOF
     [ "$1" ] && exit "$1"
 }
@@ -31,6 +32,30 @@ EOF
     if [ $code -eq 0 ] ; then
         echo "$url"
         echo "--> The URL below will expire in $expire days." >&2
+    else
+        echo "==> 'curl' failed with code $code." >&2
+    fi
+    return $code
+}
+0x45() {
+    local url code response expiry readable_date delete_url
+
+    # Check if jq is available
+    if ! command -v jq >/dev/null 2>&1; then
+        echo "==> 'jq' is required for 0x45.st but not installed." >&2
+        return 1
+    fi
+
+    response=$($curl --fail -F'file=@-' -Fexpires_in=$((expire * 24))h https://0x45.st/p)
+    code=$?
+    if [ $code -eq 0 ] ; then
+        url=$(jq -r '.url' <<< "$response")
+        expiry=$(jq -r '.expires_at' <<< "$response")
+        delete_url=$(jq -r '.delete_url' <<< "$response")
+        readable_date=$(date -d "${expiry}" '+%B %d, %Y at %I:%M %p %Z')
+        echo "$url"
+        echo "--> The URL below will expire on $readable_date." >&2
+        echo "--> You can delete the paste by visiting $delete_url" >&2
     else
         echo "==> 'curl' failed with code $code." >&2
     fi
@@ -50,6 +75,7 @@ Tee() {
 GeneralWarning() {
     declare -A urls=(
         [0x0]="https://0x0.st"
+        [0x45]="https://0x45.st"
         [dpaste]="https://dpaste.com"
         [termbin]="termbin.com"
     )
@@ -123,6 +149,7 @@ Main() {
     local count=0
     local services=(
         0x0
+        0x45
         dpaste
         termbin
     )
@@ -138,13 +165,13 @@ Main() {
 
     while [ "$1" ] ; do
         case "$1" in
-            --0x0 | --dpaste | --termbin)  services=("${1:2}") ;;
-            --help | -h)                   Usage 0 ;;
-            --expire=*)                    expire="${1#*=}" ;;
-            --no-yad)                      yad=no ;;
-            --infile=*)                    infile="${1#*=}"; break ;;
-            -*)                            echo2 "Unsupported option '$1'"; exit 1 ;;
-            *)                             commands="$*"; break ;;
+            --0x0 | --0x45 | --dpaste | --termbin) services=("${1:2}") ;;
+            --help | -h)   Usage 0 ;;
+            --expire=*)    expire="${1#*=}" ;;
+            --no-yad)      yad=no ;;
+            --infile=*)    infile="${1#*=}"; break ;;
+            -*)           echo2 "Unsupported option '$1'"; exit 1 ;;
+            *)           commands="$*"; break ;;
         esac
         shift
     done


### PR DESCRIPTION
Figured I'd add the paste service 0x45 (made by me) as an option here if it's welcome. Very similar to 0x0, but with some other niceties.