### PR TITLE
Default helper to defined AUR helper instead of pacman

### DIFF
--- a/eos-update
+++ b/eos-update
@@ -413,7 +413,11 @@ Main() {
 
     _init_translations
     
-    local helper=${EOS_AUR_HELPER}
+    if command -v ${EOS_AUR_HELPER} > /dev/null; then
+        local helper=${EOS_AUR_HELPER}
+    else
+        local helper=pacman
+    fi
     local min_free_bytes=$((1000 * 1000 * 1000))  # default: 1 GB
 
     local lock=/var/lib/pacman/db.lck

--- a/eos-update
+++ b/eos-update
@@ -341,12 +341,12 @@ Options:
   --pacdiff		  Run eos-pacdiff in the end of $progname. See also EOS_UPDATE_PACDIFFER
   			  in file /etc/eos-script-lib-yad.conf.
   --helper <val>          AUR helper name. Supported values: yay, paru, pacman.
-                          Default: pacman
+                          Default: The AUR helper configured in /etc/eos-script-lib-yad.conf.
                           Other AUR helpers supporting option -Sua like yay should work as well.
   --paru                  Same as --helper=paru.
   --yay                   Same as --helper=yay.
-  --aur                   Uses the AUR helper configured in /etc/eos-script-lib-yad.conf.
-  --pacman                Same as --helper=pacman. Default. (Note: pacman does not support AUR directly).
+  --aur                   Uses the AUR helper configured in /etc/eos-script-lib-yad.conf. Default.
+  --pacman                Same as --helper=pacman. (Note: pacman does not support AUR directly).
   --min-free-bytes <val>  Minimum amount of free space (in bytes) that the root partition should have
                           before updating. Otherwise a warning message will be displayed.
                           Default: $min_free_bytes
@@ -413,7 +413,7 @@ Main() {
 
     _init_translations
     
-    local helper="pacman"
+    local helper=${EOS_AUR_HELPER}
     local min_free_bytes=$((1000 * 1000 * 1000))  # default: 1 GB
 
     local lock=/var/lib/pacman/db.lck


### PR DESCRIPTION
### Proposal with respect to eos-update
Set the value of `EOS_AUR_HELPER`, defined in `/etc/eos-script-lib-yad.conf` as the default helper instead of `pacman`.  This will change the current default behaviour of `eos-update`:
* From updating native packages only.
* To updating native and AUR packages.

Simple use of `eos-update` will action a full system update, including AUR as a default, reducing risk of a partial upgrades for less aware users.  If users don't wish to update their AUR packages, it is a choice they retain, as they are naturally presented options by `yay` or `paru`.  Importantly, the user is at least aware of those updates.

If the command defined in `EOS_AUR_HELPER` cannot be found on the system, it will gracefully fallback to `pacman`.

Possible issues:
* The user may define an incompatible helper in `EOS_AUR_HELPER` (eg: not `yay` or `paru`).


~Bink