### PR TITLE
Add `ghostty` to the `suitable_terminals` in `eos-script-lib-yad`

### DIFF
--- a/eos-script-lib-yad
+++ b/eos-script-lib-yad
@@ -404,6 +404,7 @@ eos_yad_terminal() {
         kitty
         terminology
         sakura
+        ghostty
     )
     local eos_terminal_prog=""
     local xx


### PR DESCRIPTION
Ghostty is a rather new terminal emulator developed [here](https://github.com/ghostty-org/ghostty). From my testing, it seems to support the `-e` option.