### PR TITLE
Check for any package that provides dep.

### DIFF
--- a/eos-script-lib-yad
+++ b/eos-script-lib-yad
@@ -66,8 +66,8 @@ eos_assert_deps() {      # params: prog deps
     local failcount=0
     local dep
     for dep in "$@" ; do
-        expac %n "$dep" &>/dev/null || {
-           echo "==> $prog requires package '$dep'" >&2
+        expac -Qs '%n' "$dep" &>/dev/null || {
+           echo "==> $prog depends on '$dep'" >&2
            ((failcount++))
         }
     done


### PR DESCRIPTION
Make `eos_assert_deps` check for any installed package that provides `"$dep"` not named `"$dep"`.
 For example `yad-gtk2` provides `yad` so `yad` dep is met if either one is installed.